### PR TITLE
Fix UI crash when user navigates away before the download dialog appears

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
@@ -113,7 +113,7 @@ public enum StreamDialogDefaultEntry {
     DOWNLOAD(R.string.download, (fragment, item) ->
             fetchStreamInfoAndSaveToDatabase(fragment.requireContext(), item.getServiceId(),
                     item.getUrl(), info -> {
-                        if (fragment.getContext() != null) {
+                        if (fragment.isAdded() && !fragment.isStateSaved()) {
                             final DownloadDialog downloadDialog =
                                     new DownloadDialog(fragment.requireContext(), info);
                             downloadDialog.show(fragment.getChildFragmentManager(),


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

- Fixed a UI crash that occurs when a user navigates away before the download dialog appears.
- The crash was caused by an IllegalStateException when showing DownloadDialog after the fragment's state was saved.
- Implemented checks to ensure the fragment is added and its state is not saved before displaying the dialog, preventing unsafe transactions and avoiding crashes.

#### Before/After Screenshots/Screen Record

- Before: 

https://github.com/user-attachments/assets/0b1174da-ea54-45a0-9112-44600db8a4ef

- After: 

https://github.com/user-attachments/assets/2090df01-4430-4833-ae5b-170e32ad9ac3

#### Fixes the following issue(s)
- Fixes issue 11468

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
